### PR TITLE
 Admin maplist  and eros client view update.

### DIFF
--- a/starbowmodweb/ladder/admin.py
+++ b/starbowmodweb/ladder/admin.py
@@ -1,10 +1,10 @@
 from django.contrib import admin
 from starbowmodweb.ladder.models import Map, Client, BattleNetCharacter, CrashReport
 
-from modeladmins import MapModelAdmin
+import modeladmins
 
-admin.site.register(Map, MapModelAdmin)
-admin.site.register(Client)
+admin.site.register(Map, modeladmins.MapModelAdmin)
+admin.site.register(Client, modeladmins.ClientModelAdmin)
 # admin.site.register(ClientRegionStats)
 # admin.site.register(MatchmakerMatch)
 # admin.site.register(MatchmakerMatchParticipant)

--- a/starbowmodweb/ladder/admin.py
+++ b/starbowmodweb/ladder/admin.py
@@ -1,7 +1,9 @@
 from django.contrib import admin
 from starbowmodweb.ladder.models import Map, Client, BattleNetCharacter, CrashReport
 
-admin.site.register(Map)
+from modeladmins import MapModelAdmin
+
+admin.site.register(Map, MapModelAdmin)
 admin.site.register(Client)
 # admin.site.register(ClientRegionStats)
 # admin.site.register(MatchmakerMatch)

--- a/starbowmodweb/ladder/modeladmins/__init__.py
+++ b/starbowmodweb/ladder/modeladmins/__init__.py
@@ -1,5 +1,7 @@
 from map import MapModelAdmin
+from client import ClientModelAdmin
 
 __all__ = [
-    'MapModelAdmin'
+    'MapModelAdmin',
+    'ClientModelAdmin',
 ]

--- a/starbowmodweb/ladder/modeladmins/__init__.py
+++ b/starbowmodweb/ladder/modeladmins/__init__.py
@@ -1,0 +1,5 @@
+from map import MapModelAdmin
+
+__all__ = [
+    'MapModelAdmin'
+]

--- a/starbowmodweb/ladder/modeladmins/client.py
+++ b/starbowmodweb/ladder/modeladmins/client.py
@@ -1,0 +1,5 @@
+from django.contrib import admin
+
+
+class ClientModelAdmin(admin.ModelAdmin):
+    search_fields = ('username',)

--- a/starbowmodweb/ladder/modeladmins/map.py
+++ b/starbowmodweb/ladder/modeladmins/map.py
@@ -1,0 +1,48 @@
+from django.contrib import admin
+
+MAP_UPDATE_SUCCESS_PREFIX = "1 map was"
+MAP_UPDATE_SUCCESS_PREFIX_PLUR = "{} maps were"
+
+
+class MapModelAdmin(admin.ModelAdmin):
+
+    actions = [
+        'add_to_ladder_pool',
+        'remove_from_ladder_pool',
+    ]
+
+    list_display = [
+        str,
+        'in_ranked_pool',
+    ]
+
+    list_editable = [
+        'in_ranked_pool',
+    ]
+
+    list_filter = (
+        'in_ranked_pool',
+        'region',
+    )
+
+    ordering = ('bnet_name',)
+
+    search_fields = ('bnet_name',)
+
+    def add_to_ladder_pool(self, request, queryset):
+        rows_updated = queryset.update(in_ranked_pool=True)
+        if rows_updated == 1:
+            message_bit = MAP_UPDATE_SUCCESS_PREFIX
+        else:
+            message_bit = MAP_UPDATE_SUCCESS_PREFIX_PLUR.format(rows_updated)
+        self.message_user(request, "%s successfully set as ladder maps." % message_bit)
+    add_to_ladder_pool.short_description = "Set selected maps as ladder maps"
+
+    def remove_from_ladder_pool(self, request, queryset):
+        rows_updated = queryset.update(in_ranked_pool=False)
+        if rows_updated == 1:
+            message_bit = MAP_UPDATE_SUCCESS_PREFIX
+        else:
+            message_bit = MAP_UPDATE_SUCCESS_PREFIX_PLUR.format(rows_updated)
+        self.message_user(request, "%s successfully set as unranked maps." % message_bit)
+    remove_from_ladder_pool.short_description = "Set selected maps as unranked maps"


### PR DESCRIPTION
Update admin map view. Maps can now be searched by name, filtered by being ranked or not and by region. Maps can be set as ladder maps via action and via checking/unchecking checkboxes inline.

Added searching to Eros clients in client list admin view.
